### PR TITLE
Initial commit of Marathon build process in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.changes
+*.deb
+marathon/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM docker.ocf.berkeley.edu/theocf/debian:stretch
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            bc \
+            dirmngr \
+            openjdk-8-jdk-headless
+
+RUN echo "deb http://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
+                --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+
+# Unfortunately this cannot be done in the main package installation step,
+# since sbt is in a separate apt repo, so it needs another update to install
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            sbt \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package.sh /tmp
+WORKDIR /opt/marathon
+
+CMD ["/tmp/package.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,45 @@
+try {
+    node('slave') {
+        step([$class: 'WsCleanup'])
+
+        stage('check-out-code') {
+            checkout scm
+        }
+
+        stage('build-package') {
+            sh 'make build-package'
+            archiveArtifacts artifacts: "marathon/target/*.deb,marathon/target/*.changes"
+        }
+
+        stash 'build'
+    }
+
+    if (env.BRANCH_NAME == 'master') {
+        stage("upload-stretch") {
+            build job: 'upload-changes', parameters: [
+                [$class: 'StringParameterValue', name: 'path_to_changes', value: "marathon/target/*.changes"],
+                [$class: 'StringParameterValue', name: 'dist', value: 'stretch'],
+                [$class: 'StringParameterValue', name: 'job', value: env.JOB_NAME.replace('/', '/job/')],
+                [$class: 'StringParameterValue', name: 'job_build_number', value: env.BUILD_NUMBER],
+            ]
+        }
+    }
+
+} catch (err) {
+    def subject = "${env.JOB_NAME} - Build #${env.BUILD_NUMBER} - Failure!"
+    def message = "${env.JOB_NAME} (#${env.BUILD_NUMBER}) failed: ${env.BUILD_URL}"
+
+    if (env.BRANCH_NAME == 'master') {
+        slackSend color: '#FF0000', message: message
+        mail to: 'root@ocf.berkeley.edu', subject: subject, body: message
+    } else {
+        mail to: emailextrecipients([
+            [$class: 'CulpritsRecipientProvider'],
+            [$class: 'DevelopersRecipientProvider']
+        ]), subject: subject, body: message
+    }
+
+    throw err
+}
+
+// vim: ft=groovy

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build-image:
 build-package: build-image
 	git clone https://github.com/mesosphere/marathon.git
 	cd marathon && git checkout ${MARATHON_TAG}
-	docker run -v $(CURDIR)/marathon:/opt/marathon:rw -ti marathon-build
+	docker run -v $(CURDIR)/marathon:/opt/marathon:rw marathon-build
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+MARATHON_TAG := v1.5.5
+
+.PHONY: build-image
+build-image:
+	docker build -t marathon-build .
+
+.PHONY: build-package
+build-package: build-image
+	git clone https://github.com/mesosphere/marathon.git
+	cd marathon && git checkout ${MARATHON_TAG}
+	docker run -v $(CURDIR)/marathon:/opt/marathon:rw -ti marathon-build
+
+.PHONY: clean
+clean:
+	rm -rf marathon

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This command is quite finicky, it doesn't appear to be able to be set up or
+# split across lines without breaking it in strange ways. Thanks sbt.
+sbt ';session clear-all ;set SystemloaderPlugin.projectSettings ++ SystemdPlugin.projectSettings ;packageDebianForLoader'
+
+for file in /opt/marathon/target/packages/systemd*.deb; do
+  # Rename the package to remove anything before (and including) the first
+  # hyphen (-). This is to rename the package to have the correct name that the
+  # .changes file contains. For some reason the .changes file contains a
+  # different name for the package, but the correct checksums.
+  mv -v "$file" /opt/marathon/target/"${file#*-}"
+done


### PR DESCRIPTION
This builds a systemd-based Marathon Debian package on stretch with the version specified at the top of the Makefile. There's not too much to the actual code here, but getting it set up with the right `sbt` commands was a bit annoying. `sbt` doesn't seem to be very flexible on how it is given its commands (they have to be all in one command, have to be in quotes, and have to be semicolon-separated with a semicolon in the front), so that wasn't very fun to get working.

Also, this takes about 10 minutes to build and uses 4.5 GB of memory each time, so there's that.